### PR TITLE
Logging and a few minor edits

### DIFF
--- a/app.html
+++ b/app.html
@@ -8,18 +8,18 @@
 
   <body>
 
-    <select id="menuNodes" onclick="app.menuNodes(this)">
+    <select id="menuNodes" onclick="app.menuNodes(this); app.logTableRequest(this)">
       <option value="">-- Nodes --</option>
     </select>
-  <input  type="button" value="New" onclick="app.menuNodes(this)">
+  <input  type="button" id = "New" value="New" onclick="app.menuNodes(this); app.logTableRequest(this)">
 
-  <select id="menuRelations" onclick="app.menuRelations(this)">
+  <select id="menuRelations" onclick="app.menuRelations(this); app.logTableRequest(this)">
     <option value="">-- Relations --</option>
   </select>
 
 <hr>
   |-> debugging
-<select onclick="app.menuDBstats(this)">
+<select id = "metaData" onclick="app.menuDBstats(this); app.logTableRequest(this)">
   <option value="">--Meta Data--</option>
   <option value="trash">Trash</option>
   <option value="nodes">Nodes</option>

--- a/app.js
+++ b/app.js
@@ -31,10 +31,10 @@ widget(method, widgetElement) {
 	// app.widget("add",this) on widget to get back to method from html to class
 	const id = this.widgetGetId(widgetElement);
 	if (id) {
-		this.widgets[id][method](widgetElement);
+		this.widgets[id][method](widgetElement); //  Call the method, which belongs to the widget containing widgetElement, and pass in widgetElement?
 	} else {
      // create instance of widget and remember it
-		 alert("App.wdiget: Erorr, method= "+ method);
+		 alert("App.widget: Error, method= "+ method);
 	}
 }
 
@@ -89,6 +89,61 @@ log(message){
 	}
 }
 
+// new methods for logging actions start there
+
+// Logs when any text field is changed, either in a widgetTableNodes or a widgetNode object.
+logText(textBox) {
+	let text = textBox.value;
+	let element = textBox.getAttribute("db");
+	let id = this.widgetGetId(textBox);
+	this.log("Field '" + element + "' in widget with ID " + id + " was set to '" + text + "'.");
+}
+
+// Logs when any button in a widget is clicked. That means any button but New, which is handled by logTableRequest.
+logButton(button) {
+	let name = button.value;
+	let id = this.widgetGetId(button);
+	this.log("The " + name + " button on widget with ID " + id + " was clicked.");
+}
+
+// Logs when the limit in a widgetTableNodes object is changed. This is handled separately from logText because labels don't have a db attribute.
+logLimit(limitBox) {
+	let id = this.widgetGetId(limitBox);
+	let limit = limitBox.value;
+	this.log("The limit for widget with id " + id + " was changed to " + limit + ".");
+}
+
+// Logs when either dropdown list or the New button is used to create a new table.
+logTableRequest(control) { // control may be either dropdown list OR the "New" button.
+	let value = "";
+	let controlName = control.id;
+	if (controlName == "New") { // If the control was the New button, go get the value from the dropdown List
+		let dropDown = document.getElementById('menuNodes');
+		value = dropDown.options[dropDown.selectedIndex].value;
+	}
+	else { // if the control used wasn't the New button, it was the dropdown list itself
+		value = control.options[control.selectedIndex].value;
+	}
+	this.log("The control '" + controlName + "' was used to request a new '" + value + "' table.");
+}
+
+// Logs when a record is opened for editing
+logEdit(element) { // Element is the thing you clicked on to open the Edit widget - a node ID in a table
+	let id = element.innerHTML;
+	let widgetID = this.widgetGetId(element);
+	this.log ("The record with ID " + id + " in the widget with ID " + widgetID + " was opened for editing.")
+}
+
+// Logs when the search criterion for an input field changes
+logSearchChange(selector) { // selector is the dropdown which chooses among "S", "M" or "E" for strings, and "<", ">", "<=", ">=" or "=" for numbers.
+	let id = this.widgetGetId(selector);
+	let input = selector.previousElementSibling;
+	let field = input.getAttribute("db");
+	let value = selector.options[selector.selectedIndex].value
+	this.log("The search criterion for the field '" + field + "' in widget with ID " + id + " was changed to '" + value + "'.");
+}
+
+// End of new methods for logging actions
 
 // toggle log on off
 logToggle(button){
@@ -125,8 +180,8 @@ widgetSearch(domElement) {
 widgetHeader(){
 	return(`
 <div id="#0#" class="widget" db="nameTable: #tableName#"><hr>
-<input type="button" value="X"   onclick="app.widgetClose(this)">
-<input type="button" value="__" onclick="app.widgetCollapse(this)">
+<input type="button" value="X"   onclick="app.widgetClose(this); app.logButton(this)">
+<input type="button" value="__" onclick="app.logButton(this); app.widgetCollapse(this)">
 		`)
 }
 

--- a/widgetNode.js
+++ b/widgetNode.js
@@ -30,7 +30,7 @@ constructor(label, data) {
 ////////////////////////////////////////////////////////////////////
 buildWidget() { // public - build table header
   const html = app.widgetHeader() +'<b> ' + this.label +` </b>
-  <input id="#1#" type="button" onclick="app.widget('saveAdd',this)">
+  <input id="#1#" type="button" onclick="app.widget('saveAdd',this); app.logButton(this)">
   <table id="#2#">
   </table>
   </div>
@@ -50,7 +50,7 @@ buildData() {
   let html="";
   for (var fieldName in this.fields) {
       let s1 = '<tr><th>' + this.fields[fieldName].label + '</th><td><input db="' + fieldName
-      + `" onChange="app.widget('changed',this)"`  +' #value#></td></tr>'
+      + `" onChange="app.widget('changed',this); app.logText(this)"`  +' #value#></td></tr>'
       let s2="";
       if (this.data) {
         // load form with data from db, edit

--- a/widgetTableNodes.js
+++ b/widgetTableNodes.js
@@ -123,9 +123,9 @@ buildHeader() {
   // build header
   const html = app.widgetHeader()
   +'<b> '+this.queryObject.nodeLabel +":"+ this.queryObjectName +` </b>
-  <input type="button" value="Add"     onclick="app.widget('addNode',this)">
-  <input type="button" value="Search"  onclick="app.widgetSearch(this)">
-  limit <input id="#1#" value ="9" style="width: 20px;">
+  <input type="button" value="Add"     onclick="app.widget('addNode',this); app.logButton(this)">
+  <input type="button" value="Search"  onclick="app.widgetSearch(this); app.logButton(this)">
+  limit <input id="#1#" value ="9" style="width: 20px;" onblur = "app.logLimit(this)">
 
   <table>
     <thead id="#2#">
@@ -139,7 +139,7 @@ buildHeader() {
   `
 
   const strSearch = `
-  <select>
+  <select onclick = "app.logSearchChange(this)">
   <option value="S">S</option>
   <option value="M">M</option>
   <option value="E">E</option>
@@ -147,7 +147,7 @@ buildHeader() {
   </select></th>`
 
   const numSearch = `
-  <select>
+  <select onclick = "app.logSearchChange(this)">
   <option value=">">&gt;</option>
   <option value=">=">&gt;=</option>
   <option value="=">=</option>
@@ -162,7 +162,7 @@ buildHeader() {
   let s="";
   for (let i=0; i<this.fieldsDisplayed.length; i++ ) {
       let fieldName =this.fieldsDisplayed[i];
-      let s1 = `<th><input db="fieldName: #1" size="7">`
+      let s1 = `<th><input db="fieldName: #1" size="7" onblur="app.logText(this)">`
       if (this.fields[fieldName].type === "number") {
         // number search
         s1 += numSearch;
@@ -194,7 +194,7 @@ buildData(data) {  // build dynamic part of table
   const r = data;
   let rowCount = 1;
   for (let i=0; i<r.length; i++) {
-    html += '<tr><td>' +rowCount++ + `</td><td onClick="app.widget('edit',this)">` +r[i]["n"].identity+ '</td>'
+    html += '<tr><td>' +rowCount++ + `</td><td onClick="app.widget('edit',this); app.logEdit(this)">` +r[i]["n"].identity+ '</td>'
     for (let j=0; j<this.fieldsDisplayed.length; j++) {
       let fieldName =this.fieldsDisplayed[j];
       html += '<td '+ this.getatt(fieldName) +'>'+ r[i]["n"].properties[fieldName]  +"</td>" ;


### PR DESCRIPTION
I made every control I could find that does anything create a one-line addition to the log file. Specifically, I can now log:

When any dropdown menu or the New button is used to create a new table (including Relations, once it is working)
When any table is expanded, collapsed or closed
When the Add or Search button on a widgetTableNode table is clicked
When a search field in a widgetTableNode table is edited
When the criterion associated with a search field (that is, S, M, E, <, >, <=, >=, or =) in a widgetTableNode is edited
When the limit for a widgetTableNode table is edited
When a record from a widgetTableNode table is opened for editing by clicking its ID
When a field in the widgetNode table for a record is edited
When the Add or Save button for a widgetNode table is clicked
And of course, when the Log Start button is clicked. (I didn't log the Log Stop button. What would be the point?)

For each of these events, I log the ID of the widget it took place in, if any; the name of the field or button involved, if applicable; and the value entered, for a text box.

To do this, I added onclick, onchange or onblur events to all of the affected controls, and added ids to a few. Most of the changes are in app.js, where I placed the methods which create the log entries. I also corrected a few typos and added a few comments.