### PR TITLE
Amy simplify ids experiment

### DIFF
--- a/app.html
+++ b/app.html
@@ -8,18 +8,18 @@
 
   <body>
 
-    <select id="menuNodes" onclick="app.menuNodes(this); app.logTableRequest(this)">
+    <select id="menuNodes" onclick="app.menuNodes(this)">
       <option value="">-- Nodes --</option>
     </select>
-  <input  type="button" id = "New" value="New" onclick="app.menuNodes(this); app.logTableRequest(this)">
+  <input  type="button" id = "New" value="New" onclick="app.menuNodes(this)">
 
-  <select id="menuRelations" onclick="app.menuRelations(this); app.logTableRequest(this)">
+  <select id="menuRelations" onclick="app.menuRelations(this)">
     <option value="">-- Relations --</option>
   </select>
 
 <hr>
   |-> debugging
-<select id = "metaData" onclick="app.menuDBstats(this); app.logTableRequest(this)">
+<select id = "metaData" onclick="app.menuDBstats(this)">
   <option value="">--Meta Data--</option>
   <option value="trash">Trash</option>
   <option value="nodes">Nodes</option>

--- a/app.html
+++ b/app.html
@@ -8,18 +8,18 @@
 
   <body>
 
-    <select id="menuNodes" onclick="app.menuNodes(this)">
+    <select id="menuNodes" onclick="app.menuNodes(this); app.logTableRequest(this)">
       <option value="">-- Nodes --</option>
     </select>
-  <input  type="button" value="New" onclick="app.menuNodes(this)">
+  <input  type="button" id = "New" value="New" onclick="app.menuNodes(this); app.logTableRequest(this)">
 
-  <select id="menuRelations" onclick="app.menuRelations(this)">
+  <select id="menuRelations" onclick="app.menuRelations(this); app.logTableRequest(this)">
     <option value="">-- Relations --</option>
   </select>
 
 <hr>
   |-> debugging
-<select onclick="app.menuDBstats(this)">
+<select id = "metaData" onclick="app.menuDBstats(this); app.logTableRequest(this)">
   <option value="">--Meta Data--</option>
   <option value="trash">Trash</option>
   <option value="nodes">Nodes</option>

--- a/app.js
+++ b/app.js
@@ -31,10 +31,10 @@ widget(method, widgetElement) {
 	// app.widget("add",this) on widget to get back to method from html to class
 	const id = this.widgetGetId(widgetElement);
 	if (id) {
-		this.widgets[id][method](widgetElement);
+		this.widgets[id][method](widgetElement); //  Call the method, which belongs to the widget containing widgetElement, and pass in widgetElement?
 	} else {
      // create instance of widget and remember it
-		 alert("App.wdiget: Erorr, method= "+ method);
+		 alert("App.widget: Error, method= "+ method);
 	}
 }
 
@@ -89,6 +89,61 @@ log(message){
 	}
 }
 
+// new methods for logging actions start there
+
+// Logs when any text field is changed, either in a widgetTableNodes or a widgetNode object.
+logText(textBox) {
+	let text = textBox.value;
+	let element = textBox.getAttribute("db");
+	let id = this.widgetGetId(textBox);
+	this.log("Field '" + element + "' in widget with ID " + id + " was set to '" + text + "'.");
+}
+
+// Logs when any button in a widget is clicked. That means any button but New, which is handled by logTableRequest.
+logButton(button) {
+	let name = button.value;
+	let id = this.widgetGetId(button);
+	this.log("The " + name + " button on widget with ID " + id + " was clicked.");
+}
+
+// Logs when the limit in a widgetTableNodes object is changed. This is handled separately from logText because labels don't have a db attribute.
+logLimit(limitBox) {
+	let id = this.widgetGetId(limitBox);
+	let limit = limitBox.value;
+	this.log("The limit for widget with id " + id + " was changed to " + limit + ".");
+}
+
+// Logs when either dropdown list or the New button is used to create a new table.
+logTableRequest(control) { // control may be either dropdown list OR the "New" button.
+	let value = "";
+	let controlName = control.id;
+	if (controlName == "New") { // If the control was the New button, go get the value from the dropdown List
+		let dropDown = document.getElementById('menuNodes');
+		value = dropDown.options[dropDown.selectedIndex].value;
+	}
+	else { // if the control used wasn't the New button, it was the dropdown list itself
+		value = control.options[control.selectedIndex].value;
+	}
+	this.log("The control '" + controlName + "' was used to request a new '" + value + "' table.");
+}
+
+// Logs when a record is opened for editing
+logEdit(element) { // Element is the thing you clicked on to open the Edit widget - a node ID in a table
+	let id = element.innerHTML;
+	let widgetID = this.widgetGetId(element);
+	this.log ("The record with ID " + id + " in the widget with ID " + widgetID + " was opened for editing.")
+}
+
+// Logs when the search criterion for an input field changes
+logSearchChange(selector) { // selector is the dropdown which chooses among "S", "M" or "E" for strings, and "<", ">", "<=", ">=" or "=" for numbers.
+	let id = this.widgetGetId(selector);
+	let input = selector.previousElementSibling;
+	let field = input.getAttribute("db");
+	let value = selector.options[selector.selectedIndex].value
+	this.log("The search criterion for the field '" + field + "' in widget with ID " + id + " was changed to '" + value + "'.");
+}
+
+// End of new methods for logging actions
 
 // toggle log on off
 logToggle(button){
@@ -125,8 +180,8 @@ widgetSearch(domElement) {
 widgetHeader(){
 	return(`
 <div id="#0#" class="widget" db="nameTable: #tableName#"><hr>
-<input type="button" value="X"   onclick="app.widgetClose(this)">
-<input type="button" value="__" onclick="app.widgetCollapse(this)">
+<input type="button" value="X"   onclick="app.widgetClose(this); app.logButton(this)">
+<input type="button" value="__" onclick="app.logButton(this); app.widgetCollapse(this)">
 		`)
 }
 

--- a/app.js
+++ b/app.js
@@ -68,18 +68,18 @@ menuNodesInit(){
 // <option value="Movie">Movie</option>
 
 /* displays nodes, allow search, add/edit */
-menuNodes(){
+menuNodes(control){
 	let dropDown = document.getElementById('menuNodes');
 	let value = dropDown.options[dropDown.selectedIndex].value;
 	if (value==="") return;  // menu comment
-	this.widgets[this.idGet(0)] = new widgetTableNodes(value);
+	this.widgets[this.idGet(0)] = new widgetTableNodes(value, control.id);
 }
 
 /* displays meta-data on nodes, keysNodes, relations, keysRelations */
 menuDBstats(dropDown){
 	let value = dropDown.options[dropDown.selectedIndex].value;
 	if (value==="") return; // menu comment
-	this.widgets[this.idGet(0)] = new widgetTableQuery(value);
+	this.widgets[this.idGet(0)] = new widgetTableQuery(value, dropDown.id);
 }
 
 /* for debugging / dev place to write messages */
@@ -89,58 +89,24 @@ log(message){
 	}
 }
 
-// new methods for logging actions start there
+// new methods for logging actions start here
 
-// Logs when any text field is changed, either in a widgetTableNodes or a widgetNode object.
+// Logs when any text field is changed in a widgetTableNodes object.
 logText(textBox) {
-	let text = textBox.value;
-	let element = textBox.getAttribute("db");
-	let id = this.widgetGetId(textBox);
-	this.log("Field '" + element + "' in widget with ID " + id + " was set to '" + text + "'.");
-}
-
-// Logs when any button in a widget is clicked. That means any button but New, which is handled by logTableRequest.
-logButton(button) {
-	let name = button.value;
-	let id = this.widgetGetId(button);
-	this.log("The " + name + " button on widget with ID " + id + " was clicked.");
-}
-
-// Logs when the limit in a widgetTableNodes object is changed. This is handled separately from logText because labels don't have a db attribute.
-logLimit(limitBox) {
-	let id = this.widgetGetId(limitBox);
-	let limit = limitBox.value;
-	this.log("The limit for widget with id " + id + " was changed to " + limit + ".");
-}
-
-// Logs when either dropdown list or the New button is used to create a new table.
-logTableRequest(control) { // control may be either dropdown list OR the "New" button.
-	let value = "";
-	let controlName = control.id;
-	if (controlName == "New") { // If the control was the New button, go get the value from the dropdown List
-		let dropDown = document.getElementById('menuNodes');
-		value = dropDown.options[dropDown.selectedIndex].value;
-	}
-	else { // if the control used wasn't the New button, it was the dropdown list itself
-		value = control.options[control.selectedIndex].value;
-	}
-	this.log("The control '" + controlName + "' was used to request a new '" + value + "' table.");
-}
-
-// Logs when a record is opened for editing
-logEdit(element) { // Element is the thing you clicked on to open the Edit widget - a node ID in a table
-	let id = element.innerHTML;
-	let widgetID = this.widgetGetId(element);
-	this.log ("The record with ID " + id + " in the widget with ID " + widgetID + " was opened for editing.")
+	let obj = {};
+	obj.id = this.widgetGetId(textBox);
+	obj.idr = textBox.getAttribute("idr");
+	obj.value = textBox.value;
+	this.log(JSON.stringify(obj));
 }
 
 // Logs when the search criterion for an input field changes
 logSearchChange(selector) { // selector is the dropdown which chooses among "S", "M" or "E" for strings, and "<", ">", "<=", ">=" or "=" for numbers.
-	let id = this.widgetGetId(selector);
-	let input = selector.previousElementSibling;
-	let field = input.getAttribute("db");
-	let value = selector.options[selector.selectedIndex].value
-	this.log("The search criterion for the field '" + field + "' in widget with ID " + id + " was changed to '" + value + "'.");
+  let obj = {};
+	obj.id = this.widgetGetId(selector);
+	obj.idr = selector.getAttribute("idr");
+	obj.value = selector.options[selector.selectedIndex].value;
+	this.log(JSON.stringify(obj));
 }
 
 // End of new methods for logging actions
@@ -174,14 +140,15 @@ widgetNode(nodeName, data) {
 widgetSearch(domElement) {
 	// called from widgetList
 	const id = this.widgetGetId(domElement);
+	this.widgets[id].searchTrigger = id;
 	this.widgets[id].search();
 }
 
 widgetHeader(){
 	return(`
 <div id="#0#" class="widget" db="nameTable: #tableName#"><hr>
-<input type="button" value="X"   onclick="app.widgetClose(this); app.logButton(this)">
-<input type="button" value="__" onclick="app.logButton(this); app.widgetCollapse(this)">
+<input type="button" value="X" idr="closeButton" onclick="app.widgetClose(this)">
+<input type="button" value="__" idr="expandCollapseButton" onclick="app.widgetCollapse(this)">
 		`)
 }
 
@@ -197,6 +164,12 @@ widgetCollapse(domElement) {
 	} else {
 		domElement.value = 	"__";
 	}
+
+	// log
+	let obj = {};
+	obj.id = this.widgetGetId(domElement);
+	obj.idr = domElement.getAttribute('idr');
+	this.log(JSON.stringify(obj));
 }
 
 
@@ -212,7 +185,13 @@ widgetClose(widgetElement) {
 
 	// delete  html2 from page
 	const widget = document.getElementById(id);
-	widget.parentElement.removeChild(widget)
+	widget.parentElement.removeChild(widget);
+
+	// log
+	let obj = {};
+	obj.id = id;
+	obj.idr = widgetElement.getAttribute("idr");
+	this.log(JSON.stringify(obj));
 }
 
 

--- a/app.js
+++ b/app.js
@@ -72,14 +72,14 @@ menuNodes(control){
 	let dropDown = document.getElementById('menuNodes');
 	let value = dropDown.options[dropDown.selectedIndex].value;
 	if (value==="") return;  // menu comment
-	this.widgets[this.idGet(0)] = new widgetTableNodes(value, control.id);
+	this.widgets[this.idCounter] = new widgetTableNodes(value, control.id);
 }
 
 /* displays meta-data on nodes, keysNodes, relations, keysRelations */
 menuDBstats(dropDown){
 	let value = dropDown.options[dropDown.selectedIndex].value;
 	if (value==="") return; // menu comment
-	this.widgets[this.idGet(0)] = new widgetTableQuery(value, dropDown.id);
+	this.widgets[this.idCounter] = new widgetTableQuery(value, dropDown.id);
 }
 
 /* for debugging / dev place to write messages */
@@ -88,8 +88,6 @@ log(message){
 		document.getElementById('log').innerHTML += "<br>" + message;
 	}
 }
-
-// new methods for logging actions start here
 
 // Logs when any text field is changed in a widgetTableNodes object.
 logText(textBox) {
@@ -109,8 +107,6 @@ logSearchChange(selector) { // selector is the dropdown which chooses among "S",
 	this.log(JSON.stringify(obj));
 }
 
-// End of new methods for logging actions
-
 // toggle log on off
 logToggle(button){
 	log = document.getElementById('log');
@@ -128,11 +124,11 @@ logToggle(button){
 // brings up add/edit widget form table for one node
 // keys in first column, values in second column
 widgetNodeNew(nodeName, data) {
-		this.widgets[this.idGet(0)] = new widgetNode(nodeName, data);
+		this.widgets[this.idCounter] = new widgetNode(nodeName, data);
 }
 
 widgetNode(nodeName, data) {
-		this.widgets[this.idGet(0)] = new widgetNode(nodeName, data);
+		this.widgets[this.idCounter] = new widgetNode(nodeName, data);
 }
 
 
@@ -146,7 +142,7 @@ widgetSearch(domElement) {
 
 widgetHeader(){
 	return(`
-<div id="#0#" class="widget" db="nameTable: #tableName#"><hr>
+<div id="` + this.idCounter++ + `" class="widget"><hr>
 <input type="button" value="X" idr="closeButton" onclick="app.widgetClose(this)">
 <input type="button" value="__" idr="expandCollapseButton" onclick="app.widgetCollapse(this)">
 		`)
@@ -219,24 +215,35 @@ idGet(increment) {  // was  get
 	return (this.idCounter+increment).toString();
 }
 
-// when is this used?
-idGetLast() { // was getLast
-	return app.widgets[this.idCounter];
-}
+// // when is this used?
+// idGetLast() { // was getLast
+// 	return app.widgets[this.idCounter];
+// }
 
 // replace id holder in widget header with unique ids
-idReplace(html, counter) { // public - was replace
-	// called once for each widget created
-	//replace #id0# with id.counter, #id1# with id.counter+1 etc, then increment counter to next unused id
-	let ret = html.replace("#"+counter++ +"#", "" + this.idCounter++);
-  if (html === ret) {
-		// all the replacements have been done - assume no ids are skipped, will break code
-		// save widget
-		return (ret);
-	} else {
-		// recursively call until there are no more changes to make
-		return( this.idReplace(ret, counter));
-}}
+// idReplace(html, counter) { // public - was replace
+// 	// called once for each widget created
+// 	//replace #id0# with idCounter, #id1# with idCounter+1 etc, then increment idCounter to next unused id
+// 	let ret = html.replace("#"+counter++ +"#", "" + this.idCounter++);
+//   if (html === ret) {
+// 		// all the replacements have been done - assume no ids are skipped, will break code
+// 		// save widget
+// 		return (ret);
+// 	} else {
+// 		// recursively call until there are no more changes to make
+// 		return( this.idReplace(ret, counter));
+// }}
+
+// returns the first child of the given element that has the given idr. If no child has that idr, returns null.
+getChildByIdr(element, idr) {
+	let children = element.querySelectorAll("*"); // get all the element's children...
+	for (let i = 0; i < children.length; i++) { // loop through them...
+		if (children[i].getAttribute("idr") == idr) {
+			return children[i]; // and return the first one whose idr matches...
+		}
+	}
+	return null; // or null if no idr matches
+}
 
 test() {
 	// test
@@ -250,7 +257,7 @@ test() {
 	this.widgets[this.idGet(0)] = new widgetTableQuery('keysRelation');  // seems to work
 */
 
-	this.widgets[this.idGet(0)] = new widgetTableNodes('people');
+	this.widgets[this.idCounter] = new widgetTableNodes('people');
 /*
 
 

--- a/widgetNode.js
+++ b/widgetNode.js
@@ -30,7 +30,7 @@ constructor(label, data) {
 ////////////////////////////////////////////////////////////////////
 buildWidget() { // public - build table header
   const html = app.widgetHeader() +'<b> ' + this.label +` </b>
-  <input id="#1#" type="button" onclick="app.widget('saveAdd',this)">
+  <input id="#1#" type="button" onclick="app.widget('saveAdd',this); app.logButton(this)">
   <table id="#2#">
   </table>
   </div>
@@ -50,7 +50,7 @@ buildData() {
   let html="";
   for (var fieldName in this.fields) {
       let s1 = '<tr><th>' + this.fields[fieldName].label + '</th><td><input db="' + fieldName
-      + `" onChange="app.widget('changed',this)"`  +' #value#></td></tr>'
+      + `" onChange="app.widget('changed',this); app.logText(this)"`  +' #value#></td></tr>'
       let s2="";
       if (this.data) {
         // load form with data from db, edit

--- a/widgetNode.js
+++ b/widgetNode.js
@@ -3,7 +3,7 @@
 add/edit one node in a form
 
 input: label
-       data is optional.  Add mode is used if data is not suplied
+       data is optional.  Add mode is used if data is not supplied
 
 */
 
@@ -30,7 +30,7 @@ constructor(label, data) {
 ////////////////////////////////////////////////////////////////////
 buildWidget() { // public - build table header
   const html = app.widgetHeader() +'<b> ' + this.label +` </b>
-  <input id="#1#" type="button" onclick="app.widget('saveAdd',this); app.logButton(this)">
+  <input id="#1#" idr = "addSaveButton" type="button" onclick="app.widget('saveAdd',this)">
   <table id="#2#">
   </table>
   </div>
@@ -48,9 +48,10 @@ buildWidget() { // public - build table header
 buildData() {
   // put in one field label and input row for each field
   let html="";
+  let fieldCount = 0;
   for (var fieldName in this.fields) {
       let s1 = '<tr><th>' + this.fields[fieldName].label + '</th><td><input db="' + fieldName
-      + `" onChange="app.widget('changed',this); app.logText(this)"`  +' #value#></td></tr>'
+      + `" idr = "input` + fieldCount++ + `" onChange="app.widget('changed',this)"`  +' #value#></td></tr>'
       let s2="";
       if (this.data) {
         // load form with data from db, edit
@@ -79,6 +80,13 @@ saveAdd(widgetElement) {
   } else {
     this.add(widgetElement);
   }
+
+  // log
+  let obj = {};
+  obj.id = app.widgetGetId(widgetElement);
+  obj.idr = widgetElement.getAttribute("idr");
+  obj.value = widgetElement.value;
+  app.log(JSON.stringify(obj));
 }
 
 
@@ -112,14 +120,27 @@ addComplete(data) {
 
 
 changed(input) {
-  if (!this.data) return;  // no feedback in add mode
-
+  if (!this.data) {
+    let obj = {};
+    obj.id = app.widgetGetId(input);
+    obj.idr = input.getAttribute("idr");
+    obj.value = input.value;
+    app.log(JSON.stringify(obj));    
+    return;  // no feedback in add mode, but do log the change
+  }
   // give visual feedback if edit data is different than db data
   if (input.value === this.data.properties[input.getAttribute('db')]) {
     input.setAttribute("class","");
   } else {
     input.setAttribute("class","changedData");
   }
+
+  // log
+  let obj = {};
+  obj.id = app.widgetGetId(input);
+  obj.idr = input.getAttribute("idr");
+  obj.value = input.value;
+  app.log(JSON.stringify(obj));
 }
 
 

--- a/widgetNode.js
+++ b/widgetNode.js
@@ -11,13 +11,13 @@ class widgetNode {
 constructor(label, data) {
   this.data        = data; // is db identifier, not defined means add
   this.label       = label;
-  this.idWidget    = app.idGet(0); // not sure this is used
-  this.addSave     = app.idGet(1);
+  this.idWidget    = app.idGet(0);
+//  this.addSave     = app.idGet(1);
   this.addSaveDOM  = {} // place holder
-  this.table       = app.idGet(2);
+//  this.table       = app.idGet(2);
   this.tableDOM    = {} // place holder
-  this.delete       = app.idGet(3);
-  this.deleteDOM    = {} // place holder
+//  this.delete       = app.idGet(3); // Is this ever used? I can't find a reference to it, and it seems to refer to a null object
+//  this.deleteDOM    = {} // place holder
   this.queryObject = app.metaData.getNode(label);
   this.fields      = this.queryObject.fields;
   this.db          = new db() ; // placeholder for add
@@ -30,18 +30,21 @@ constructor(label, data) {
 ////////////////////////////////////////////////////////////////////
 buildWidget() { // public - build table header
   const html = app.widgetHeader() +'<b> ' + this.label +` </b>
-  <input id="#1#" idr = "addSaveButton" type="button" onclick="app.widget('saveAdd',this)">
-  <table id="#2#">
+  <input idr = "addSaveButton" type="button" onclick="app.widget('saveAdd',this)">
+  <table idr = "nodeTable">
   </table>
   </div>
   `
-  const html1 = app.idReplace(html,0);  // replace relative ids with absolute ids
-  document.getElementById('widgets').innerHTML = html1
+  document.getElementById('widgets').innerHTML = html
     + document.getElementById('widgets').innerHTML;
 
-  this.addSaveDOM = document.getElementById(this.addSave);
-  this.tableDOM   = document.getElementById(this.table);
-  this.deleteDOM  = document.getElementById(this.delete);
+    // By this point, the new widget div has been created by buildHeader() and added to the page by the above line
+
+  let widget = document.getElementById(this.idWidget);
+
+  this.addSaveDOM = app.getChildByIdr(widget, "addSaveButton");
+  this.tableDOM   = app.getChildByIdr(widget, "nodeTable");
+//  this.deleteDOM  = document.getElementById(this.delete);
 }
 
 
@@ -125,7 +128,7 @@ changed(input) {
     obj.id = app.widgetGetId(input);
     obj.idr = input.getAttribute("idr");
     obj.value = input.value;
-    app.log(JSON.stringify(obj));    
+    app.log(JSON.stringify(obj));
     return;  // no feedback in add mode, but do log the change
   }
   // give visual feedback if edit data is different than db data

--- a/widgetTableNodes.js
+++ b/widgetTableNodes.js
@@ -123,9 +123,9 @@ buildHeader() {
   // build header
   const html = app.widgetHeader()
   +'<b> '+this.queryObject.nodeLabel +":"+ this.queryObjectName +` </b>
-  <input type="button" value="Add"     onclick="app.widget('addNode',this)">
-  <input type="button" value="Search"  onclick="app.widgetSearch(this)">
-  limit <input id="#1#" value ="9" style="width: 20px;">
+  <input type="button" value="Add"     onclick="app.widget('addNode',this); app.logButton(this)">
+  <input type="button" value="Search"  onclick="app.widgetSearch(this); app.logButton(this)">
+  limit <input id="#1#" value ="9" style="width: 20px;" onblur = "app.logLimit(this)">
 
   <table>
     <thead id="#2#">
@@ -139,7 +139,7 @@ buildHeader() {
   `
 
   const strSearch = `
-  <select>
+  <select onclick = "app.logSearchChange(this)">
   <option value="S">S</option>
   <option value="M">M</option>
   <option value="E">E</option>
@@ -147,7 +147,7 @@ buildHeader() {
   </select></th>`
 
   const numSearch = `
-  <select>
+  <select onclick = "app.logSearchChange(this)">
   <option value=">">&gt;</option>
   <option value=">=">&gt;=</option>
   <option value="=">=</option>
@@ -162,7 +162,7 @@ buildHeader() {
   let s="";
   for (let i=0; i<this.fieldsDisplayed.length; i++ ) {
       let fieldName =this.fieldsDisplayed[i];
-      let s1 = `<th><input db="fieldName: #1" size="7">`
+      let s1 = `<th><input db="fieldName: #1" size="7" onblur="app.logText(this)">`
       if (this.fields[fieldName].type === "number") {
         // number search
         s1 += numSearch;
@@ -194,7 +194,7 @@ buildData(data) {  // build dynamic part of table
   const r = data;
   let rowCount = 1;
   for (let i=0; i<r.length; i++) {
-    html += '<tr><td>' +rowCount++ + `</td><td onClick="app.widget('edit',this)">` +r[i]["n"].identity+ '</td>'
+    html += '<tr><td>' +rowCount++ + `</td><td onClick="app.widget('edit',this); app.logEdit(this)">` +r[i]["n"].identity+ '</td>'
     for (let j=0; j<this.fieldsDisplayed.length; j++) {
       let fieldName =this.fieldsDisplayed[j];
       html += '<td '+ this.getatt(fieldName) +'>'+ r[i]["n"].properties[fieldName]  +"</td>" ;

--- a/widgetTableNodes.js
+++ b/widgetTableNodes.js
@@ -18,12 +18,14 @@ constructor (queryObjectName, controlId) { // name of a query Object, and ID of 
   this.queryData       = {}; // where returned data will be stored
 
   this.idWidget = app.idGet(0);   // strings
-  this.idLimit  = app.idGet(1);
-  this.idHeader = app.idGet(2);
-  this.idData   = app.idGet(3);
+//  this.idLimit  = app.idGet(1);
+//  this.idHeader = app.idGet(2);
+//  this.idData   = app.idGet(3);
   this.searchTrigger = controlId;
 
   this.buildHeader();  //  show table header on screen
+  this.widget = document.getElementById(this.idWidget);
+
   this.search();       // do search with no criteria
 }
 
@@ -40,7 +42,7 @@ buildQuery() { // public - called when search criteria change
   let match    = "(n:" +this.queryObject.nodeLabel+ ")";
   let where    = this.buildWhere();
   let orderBy  = "n." + this.queryObject.orderBy;
-  let limit    = document.getElementById(this.idLimit).value;
+  let limit    = app.getChildByIdr(this.widget, "limit").value;
 
   let query =
 	    "match " + match
@@ -57,7 +59,7 @@ buildQuery() { // public - called when search criteria change
 buildWhere() {
   /*   output - nameLast =~"(?i)Bol.*"
   */  // <tr><th><input>  must go up 2 levels to get to tr
-  const th  = document.getElementById(this.idHeader).firstElementChild.children; // get collection of th
+  const th  = app.getChildByIdr(this.widget, "header").firstElementChild.children; // get collection of th
 
   let where = "n._trash = '' and ";
   // iterate siblings of input
@@ -126,14 +128,14 @@ buildHeader() {
   +'<b> '+this.queryObject.nodeLabel +":"+ this.queryObjectName +` </b>
   <input type="button" value="Add" idr = "AddButton" onclick="app.widget('addNode',this)">
   <input type="button" value="Search" idr = "SearchButton" onclick="app.widgetSearch(this)">
-  limit <input id="#1#" value ="9" idr = "limit" style="width: 20px;" onblur = "app.logText(this)">
+  limit <input value ="9" idr = "limit" style="width: 20px;" onblur = "app.logText(this)">
 
   <table>
-    <thead id="#2#">
+    <thead idr = "header">
     <tr><th></th><th></th>#headerSearch#</tr>
     <tr><th>#</th><th>ID</th>#header#</tr>
     </thead>
-    <tbody id="#3#"> </tbody>
+    <tbody idr = "data"> </tbody>
   </table>
   <!-- popup goes here -->
   </div>
@@ -156,8 +158,8 @@ buildHeader() {
   <option value="<">&lt;</option>
   </select></th>`
 
-  const html2 = app.idReplace(html,0);  // replace relative ids with absolute ids
-  const html3 = html2.replace('#tableName#',this.tableName);
+//  const html2 = app.idReplace(html,1);  // replace relative ids with absolute ids
+//  const html3 = html.replace('#tableName#',this.tableName); // This variable doesn't seem to exist
 
   // build search part of buildHeader
   let s="";
@@ -173,7 +175,7 @@ buildHeader() {
       }
       s += s1.replace('#1',fieldName)
   }
-  const html4 = html3.replace('#headerSearch#',s)
+  const html4 = html.replace('#headerSearch#',s)
 
   // build field name part of header
   let f="";
@@ -203,7 +205,7 @@ buildData(data) {  // build dynamic part of table
     html += "</tr>"
   }
 
-  document.getElementById(this.idData).innerHTML = html;
+  app.getChildByIdr(this.widget, "data").innerHTML = html;
 
   // New code for creating a JSON object
   let obj = {};

--- a/widgetTableQuery.js
+++ b/widgetTableQuery.js
@@ -8,7 +8,7 @@ display a cypher query in a table, used mainly for meta data reporting
 
 ////////////////////////////////////////////////////////////////////  class start
 class widgetTableQuery {
-constructor (nameQueryObject) {
+constructor (nameQueryObject, id) {
   // init instance variables
   this.html            = ""; // will contain html that makes up widget
   this.queryObjectName = nameQueryObject;  // key to select queryObj
@@ -16,6 +16,7 @@ constructor (nameQueryObject) {
   this.queryObj        = this.queryObjects[nameQueryObject];  // select one query
   this.fields          = this.queryObj.fields;
   this.tableName = nameQueryObject;
+  this.dropdownId = id;
 
   this.db        = new db();   // create object to make query
   this.db.setQuery(this.queryObj.query);
@@ -35,6 +36,13 @@ queryComplete(data) {
   // add
   document.getElementById('widgets').innerHTML =
     this.html + document.getElementById('widgets').innerHTML;
+
+  // log
+  let obj = {};
+  obj.id = this.dropdownId;
+  obj.value = this.queryObjectName;
+  obj.data = data;
+  app.log(JSON.stringify(obj));
 }
 
 

--- a/widgetTableQuery.js
+++ b/widgetTableQuery.js
@@ -59,8 +59,8 @@ buildHeader() {
   </div>
   `
 
-  const html2 = app.idReplace(html,0);  // replace relative ids with absolute ides
-  const html3 = html2.replace('#tableName#',this.tableName).replace("#header#",
+//  const html2 = app.idReplace(html,1);  // replace relative ids with absolute ides
+  const html3 = html.replace("#header#",
   // create html for header
   (function(fields) {
   	// build search part of buildHeader


### PR DESCRIPTION
I simplified the ID system by using absolute IDs for widgets and idrs for elements within widgets. I introduced a new method, getChildByIdr, and commented out the idReplace method, which was no longer needed. 

This branch is based on an earlier branch of mine, Amy Record Script, in which I made every control log stringified JSON objects when logging was turned on. The JSON objects have four possible keys:

id: The id of the control if it is not in a widget, or the parent widget if the control is in a widget. The only key which is ALWAYS used.
idr: The relative ID of the control within the widget. Used only when the control IS in a widget.
value: The value of the control, if that value was set by the user (that is, if the control is a text box or dropdown list)
data: If the interaction with the control produced a query, this is the data that was returned.