### PR TITLE
Added recording and replay

### DIFF
--- a/app.html
+++ b/app.html
@@ -28,7 +28,14 @@
   <option value="keysRelation">Keys</option>
 </select>
 
-  <input type="button" value="log start" onclick="app.logToggle(this)">
+  <input type="button" id = "LogButton" value="log start" onclick="app.regression.logToggle(this)">
+  <input type="button" id = "Record" value="Record" onclick="app.regression.recordToggle(this)">
+  <input type ="button" id = "Clear" value = "Clear ALL" onclick = "app.regression.clearAll()">
+  Select a playback file:
+  <input type="file" id="playback">
+  <input type="button" value = "Replay" onclick = "app.regression.play()">
+
+  <p id="dlink">Download link goes here</p>
 
   <input id="debug" type="text" size="80">
    <a href="http://localhost:7474/browser/" target="_blank">neo4j browser </a> neo4j desktop must be running with database started
@@ -44,12 +51,18 @@
 <script src="widgetTableNodes.js"></script>
 <script src="widgetNode.js"></script>
 <script src="MetaData.js"></script>
+<script src="regressionTesting.js"></script>
 <!--
 <script src="widgetNode.js"></script>
 -->
+<div id="log" hidden="true"></div>
+<hr>
+  </body>
+</html>
 
 <script type="text/javascript">
-app = new app();  // only global varia
+app = new app();  // only global variables
+app.regression = new regressionTesting();
 app.test();
 
 // build node menu
@@ -60,10 +73,7 @@ app.metaData = new metaData();
 app.menuNodesInit();
 
 </script>
-<div id="log" hidden="true"></div>
-<hr>
-  </body>
-</html>
+
 
 <!-- where all the widgets go
   <div draggable="true" style="position: absolute;  background-color: #cc3300;  padding: 10px; color: white; ">

--- a/app.js
+++ b/app.js
@@ -19,6 +19,12 @@ constructor() {
 	// called once by app.js to create the one instance
 	this.widgets   = {}; // store widgets as they are created, remove when closed
 	this.idCounter = 0;  // init id counter
+	// this.recording = false;
+	// this.recordText = {};
+	// this.recordedStep = 1;
+	// this.playing = false;
+	// this.playbackObj = {};
+	// this.instruction = 2;
 	this.metaData  = new metaData();
 
 	// used by classDB to access neo4j database,
@@ -38,7 +44,6 @@ widget(method, widgetElement) {
 	}
 }
 
-
 // menuNodesInit(data){
 // 	let menu = document.getElementById('menuNodes');
 // 	const selectionTemplate = '<option value="#db#">#db#</option>'
@@ -49,6 +54,17 @@ widget(method, widgetElement) {
 //   }
 // 	menu.innerHTML += html;
 // }
+// returns the first child of the given element that has the given idr. If no child has that idr, returns null.
+getChildByIdr(element, idr) {
+	let children = element.querySelectorAll("*"); // get all the element's children...
+	for (let i = 0; i < children.length; i++) { // loop through them...
+		//alert("Checking child " + i + " of widget ID " + element.id + "; idr = " + children[i].getAttribute("idr") + "; target: " + idr);
+		if (children[i].getAttribute("idr") == idr) {
+			return children[i]; // and return the first one whose idr matches...
+		}
+	}
+	return null; // or null if no idr matches
+}
 
 menuNodesInit(){
 	let menu = document.getElementById('menuNodes');
@@ -82,45 +98,6 @@ menuDBstats(dropDown){
 	this.widgets[this.idCounter] = new widgetTableQuery(value, dropDown.id);
 }
 
-/* for debugging / dev place to write messages */
-log(message){
-	if (!document.getElementById('log').hidden) {
-		document.getElementById('log').innerHTML += "<br>" + message;
-	}
-}
-
-// Logs when any text field is changed in a widgetTableNodes object.
-logText(textBox) {
-	let obj = {};
-	obj.id = this.widgetGetId(textBox);
-	obj.idr = textBox.getAttribute("idr");
-	obj.value = textBox.value;
-	this.log(JSON.stringify(obj));
-}
-
-// Logs when the search criterion for an input field changes
-logSearchChange(selector) { // selector is the dropdown which chooses among "S", "M" or "E" for strings, and "<", ">", "<=", ">=" or "=" for numbers.
-  let obj = {};
-	obj.id = this.widgetGetId(selector);
-	obj.idr = selector.getAttribute("idr");
-	obj.value = selector.options[selector.selectedIndex].value;
-	this.log(JSON.stringify(obj));
-}
-
-// toggle log on off
-logToggle(button){
-	log = document.getElementById('log');
-	log.hidden = !log.hidden;
-	if (!log.hidden) {
-		// clear Log
-		log.innerHTML = "";
-		this.log("logging started");
-		button.value = "log stop";
-	} else {
-		button.value = "log start";
-	}
-}
-
 // brings up add/edit widget form table for one node
 // keys in first column, values in second column
 widgetNodeNew(nodeName, data) {
@@ -130,7 +107,6 @@ widgetNodeNew(nodeName, data) {
 widgetNode(nodeName, data) {
 		this.widgets[this.idCounter] = new widgetNode(nodeName, data);
 }
-
 
 // /* refresh widget with new database call */
 widgetSearch(domElement) {
@@ -165,7 +141,9 @@ widgetCollapse(domElement) {
 	let obj = {};
 	obj.id = this.widgetGetId(domElement);
 	obj.idr = domElement.getAttribute('idr');
-	this.log(JSON.stringify(obj));
+	obj.action = "click";
+	this.regression.log(JSON.stringify(obj));
+	this.regression.record(obj);
 }
 
 
@@ -187,7 +165,9 @@ widgetClose(widgetElement) {
 	let obj = {};
 	obj.id = id;
 	obj.idr = widgetElement.getAttribute("idr");
-	this.log(JSON.stringify(obj));
+	obj.action = "click";
+	this.regression.log(JSON.stringify(obj));
+	this.regression.record(obj);
 }
 
 
@@ -234,16 +214,6 @@ idGet(increment) {  // was  get
 // 		return( this.idReplace(ret, counter));
 // }}
 
-// returns the first child of the given element that has the given idr. If no child has that idr, returns null.
-getChildByIdr(element, idr) {
-	let children = element.querySelectorAll("*"); // get all the element's children...
-	for (let i = 0; i < children.length; i++) { // loop through them...
-		if (children[i].getAttribute("idr") == idr) {
-			return children[i]; // and return the first one whose idr matches...
-		}
-	}
-	return null; // or null if no idr matches
-}
 
 test() {
 	// test

--- a/regressionTesting.js
+++ b/regressionTesting.js
@@ -1,0 +1,202 @@
+class regressionTesting {
+  constructor() {
+    this.logField = document.getElementById('log'); // DOM element - log field
+    this.recording = false; // whether actions are being recorded
+    this.recordText = {}; // Object storing all recorded actions
+    this.recordedStep = 1; // Number of the next action to be recorded - increments whenever an action is recorded and resets when recording stops
+    this.playing = false; // whether actions are being replayed
+    this.playbackObj = {}; // Object storing all actions to replay
+    this.instruction = 2; // Number of the next action to be replayed by next() - starts at 2 because 1 is processed by play(). Increments when an action is played, resets when Play button is clicked
+    this.db = new db();
+  }
+
+  log(message){
+  	if (!this.logField.hidden) {
+  		this.logField.innerHTML += "<br>" + message;
+  	}
+  } // end log method
+
+  // toggle log on off
+  logToggle(button){
+  	log = document.getElementById('log');
+  	log.hidden = !log.hidden;
+  	if (!log.hidden) {
+  		// clear Log
+  		log.innerHTML = "";
+  		this.log("logging started");
+  		button.value = "log stop";
+  	} else {
+  		button.value = "log start";
+  	}
+  } // end logToggle method
+
+  // Logs when any text field is changed in a widgetTableNodes object.
+  logText(textBox) {
+  	let obj = {};
+  	obj.id = app.widgetGetId(textBox);
+  	obj.idr = textBox.getAttribute("idr");
+  	obj.value = textBox.value;
+  	obj.action = "blur";
+  	this.log(JSON.stringify(obj));
+  	this.record(obj);
+  } // end logText method
+
+  // Logs when the search criterion for an input field changes
+  logSearchChange(selector) { // selector is the dropdown which chooses among "S", "M" or "E" for strings, and "<", ">", "<=", ">=" or "=" for numbers.
+    let obj = {};
+  	obj.id = app.widgetGetId(selector);
+  	obj.idr = selector.getAttribute("idr");
+  	obj.value = selector.options[selector.selectedIndex].value;
+  	obj.action = "select";
+  	this.log(JSON.stringify(obj));
+  	this.record(obj);
+  } // end logSearchChange method
+
+  record(message) {
+  	if (this.recording) {
+  		this.recordText[this.recordedStep++] = message;
+  	}
+  	if (this.playing) {
+  		this.next();
+  	}
+  } // end record method
+
+  // toggle record on and off
+  recordToggle(button){
+    if (this.recording) { // If the page was recording
+  		button.value = "Record";
+  		let text = JSON.stringify(this.recordText);
+  		if (this.playing) { // If actions were being recorded during playback
+        // // This isn't working quite right because of random ordering in nodes with the same orderBy field.
+        // // I need to either ensure that nodes are always returned in the same order, or adjust my logic for checking sameness.
+
+        // let playbackText = JSON.stringify(this.playbackObj);
+  			// if (text == playbackText) {
+  			// 	alert ("Success!");
+  			// }
+  			// else {
+  			// 	alert ("Failure! Original recording: " + playbackText + "; replay recording: " + text);
+  			// }
+  		}
+  		else { // If actions were being recorded in order to save them
+  			let uriContent = "data:application/octet-stream," + encodeURIComponent(text);
+  			document.getElementById("dlink").innerHTML = "<a href=" + uriContent + " download=\"savedfile.txt\">Here is the download link</a>";
+  		}
+  		// reset
+  		this.recordText = {};
+  		this.recordedStep = 1;
+  	}
+    else { // If the page was not recording
+  		button.value = "Stop Recording"
+  		document.getElementById("dlink").innerHTML = "Download link goes here";
+  	}
+  	this.recording = !this.recording;
+  } // end recordToggle method
+
+  // This could be more robust - if you choose the wrong file or the file is corrupted, it might exist and even contain JSON, but not be usable.
+  // I'll have to spend some time thinking about the best way of error-checking. But for now, as long as we DON'T choose the wrong file, it should be OK.
+
+  play() { // Reads a file, sets playback variables and plays back the FIRST recorded action
+  	let fileButton = document.getElementById("playback");
+  	var replayText;
+
+  	if ('files' in fileButton && fileButton.files.length >0) { // If there's a file to play back
+  		this.playing = true;
+  		this.instruction = 2;
+  		this.playbackObj = {}; // Reset playback variables
+  		if (!this.recording) {
+  			this.recordToggle(document.getElementById("Record")); // make sure app is recording
+  		}
+
+  		let myFile = fileButton.files[0];
+   		let fileReader = new FileReader();
+  		fileReader.onload = function(fileLoadedEvent){ // ANONYMOUS INNER FUNCTION STARTS HERE! Cannot use 'this' to refer to regressionTesting object here!
+  			replayText = fileLoadedEvent.target.result;
+
+  			app.regression.playbackObj = JSON.parse(replayText);
+
+  			app.regression.processPlayback(app.regression.playbackObj["1"]); // process the first instruction
+  		} // end anonymous function
+  		fileReader.readAsText(myFile, "UTF-8");
+  	} // end if (file exists)
+
+  	else {
+  		alert ("Select a file first!")
+  	}
+  } // end play method
+
+  next() { // Replays the next recorded action from a file, if it exists. If not, wraps up recording.
+  	let instString = this.instruction.toString();
+  	this.instruction++; // Prepare to go on to the next instruction
+  	if (instString in this.playbackObj) { // If there is an instruction with this number
+      this.processPlayback(this.playbackObj[instString]);
+  	}
+  	else { // Playback is finished
+  		this.recordToggle(document.getElementById("Record"));
+  		this.playing = false;
+  	}
+  } // end next method
+
+  processPlayback(instructionObj) { // takes a single instruction object as argument, plays it
+  	let id = instructionObj.id;
+  	let text = "ID: " + id;
+
+  	let element = document.getElementById(id);
+  	if ('idr' in instructionObj) {
+  		element = app.getChildByIdr(element, instructionObj.idr);
+  		text += ", IDR: " + instructionObj.idr;
+  	}
+
+  	if ('value' in instructionObj) {
+  		element.value = instructionObj.value;
+  		text += ", Value: " + instructionObj.value;
+  	}
+
+  	text += ", Action: " + instructionObj.action;
+  //	alert("Processing instruction " + text);
+
+  	switch (instructionObj.action){
+  		case "click":
+  		case "select":
+  			element.onclick();
+  			break;
+  		case "change":
+  			element.onchange();
+  			break;
+  		case "blur":
+  			element.onblur();
+  			break;
+  		default:
+  			alert("Unsupported action.");
+  	}
+  } // end processPlayback method
+
+  clearAll() {
+  	if (confirm("This will clear ALL DATA from the database and remove ALL WIDGETS from the webpage. Are you sure you want to do this?")) {
+  		for (var id in app.widgets) {
+  			// Remove widget objects
+  			delete app.widgets[id];
+
+  			// delete  html2 from page
+  			const widget = document.getElementById(id);
+  			widget.parentElement.removeChild(widget);
+  		}
+  		// Remove nodes and relationships
+  		let command = "MATCH (n) DETACH DELETE n";
+  		this.db.setQuery(command);
+  		this.db.runQuery(this, "dummy");
+
+  		// reset all variables to ensure same state every time "Clear All" is chosen
+  		app.idCounter = 0; // reset ID counter
+  		if (this.recording) {
+  			this.recordToggle(document.getElementById("Record")); // make sure app is not recording
+  		}
+//  		log = document.getElementById('log');
+  		if (!this.logField.hidden) { // If the log is active...
+  			this.logToggle(document.getElementById("LogButton")); // deactivate it
+  		}
+  	} // end if (user confirms they want to clear all)
+  } // end clearAll method
+
+  dummy() {} // Empty method, only here because runQuery has to have SOMETHING for its method argument
+} // end class

--- a/widgetNode.js
+++ b/widgetNode.js
@@ -84,12 +84,14 @@ saveAdd(widgetElement) {
     this.add(widgetElement);
   }
 
-  // log
-  let obj = {};
-  obj.id = app.widgetGetId(widgetElement);
-  obj.idr = widgetElement.getAttribute("idr");
-  obj.value = widgetElement.value;
-  app.log(JSON.stringify(obj));
+  // // log
+  // let obj = {};
+  // obj.id = app.widgetGetId(widgetElement);
+  // obj.idr = widgetElement.getAttribute("idr");
+  // obj.value = widgetElement.value;
+  // obj.action = "click";
+  // app.log(JSON.stringify(obj));
+  // app.record(obj);
 }
 
 
@@ -119,6 +121,13 @@ add(widgetElement) { // public - build table header
 addComplete(data) {
   this.data = data[0].n // takes single nodes
   this.buildData();
+  // log
+  let obj = {};
+  obj.id = this.idWidget;
+  obj.idr = "addSaveButton";
+  obj.action = "click";
+  app.regression.log(JSON.stringify(obj));
+  app.regression.record(obj);
 }
 
 
@@ -128,7 +137,9 @@ changed(input) {
     obj.id = app.widgetGetId(input);
     obj.idr = input.getAttribute("idr");
     obj.value = input.value;
-    app.log(JSON.stringify(obj));
+    obj.action = "change";
+    app.regression.log(JSON.stringify(obj));
+    app.regression.record(obj);
     return;  // no feedback in add mode, but do log the change
   }
   // give visual feedback if edit data is different than db data
@@ -143,7 +154,9 @@ changed(input) {
   obj.id = app.widgetGetId(input);
   obj.idr = input.getAttribute("idr");
   obj.value = input.value;
-  app.log(JSON.stringify(obj));
+  obj.action = "change";
+  app.regression.log(JSON.stringify(obj));
+  app.regression.record(obj);
 }
 
 
@@ -186,6 +199,13 @@ saveData(data) {
   // redo from as edit now that data is saved
   this.data = data[0].n;
   this.buildData();
+  // log
+  let obj = {};
+  obj.id = this.idWidget;
+  obj.idr = "addSaveButton";
+  obj.action = "click";
+  app.regression.log(JSON.stringify(obj));
+  app.regression.record(obj);
 }
 
 // trash(domElememt) {

--- a/widgetTableQuery.js
+++ b/widgetTableQuery.js
@@ -41,8 +41,10 @@ queryComplete(data) {
   let obj = {};
   obj.id = this.dropdownId;
   obj.value = this.queryObjectName;
+  obj.action = "select";
   obj.data = data;
-  app.log(JSON.stringify(obj));
+  app.regression.log(JSON.stringify(obj));
+  app.regression.record(obj);
 }
 
 


### PR DESCRIPTION
I added buttons to record/stop recording, download a recorded file, upload a recorded file, play a recorded file, and clear the DB and web page. I placed the variables and methods required to run these buttons in a new class, regressionTesting.js, and created an instance of that class in the app object when the page loads.

A few issues:

1) I commented out the code which compares the playback recording with the original for now, but it showed me an issue I hadn't noticed before. When two nodes are equal in the field that is indicated by "orderBy", they are returned in random order. This means that I was occasionally getting "Failure" messages, indicating that the replay didn't match the original recording, even though all the data was correct. Do we want to make sure they return in the same order every time? If so, we need to add "then by" statements so there's always a defined order for them to go in. If not, I need to change both the code that checks whether the replay gave the "same" results as the original and the code that replays a recording. I'd suggest adding the "then by" statements so the order is always the same - that seems easier to me, and I would prefer nodes not to display in random order.

2) When a new node is created, it's assigned an ID. The assigned IDs seem to increment throughout a session, but don't always start at the same number, so there's no way I can find to guarantee that creating the same node twice will result in the same ID. For the time being, I decided not to log node IDs with the data returned from search queries, because, again, they might not match during a replay even if all commands execute perfectly. If IDs need to be logged, I can look for another workaround.